### PR TITLE
update to website-stalker v0.23

### DIFF
--- a/.github/workflows/website-stalker.yml
+++ b/.github/workflows/website-stalker.yml
@@ -12,11 +12,6 @@ permissions:
 jobs:
   website-stalker:
     runs-on: ubuntu-latest
-    env:
-      WEBSITE_STALKER_FROM: ${{ secrets.WEBSITE_STALKER_FROM }}
-      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-      TELEGRAM_TARGET_CHAT: "-1001569012086"
-      TELEGRAM_DISABLE_WEB_PAGE_PREVIEW: true
     steps:
       - uses: EdJoPaTo/website-stalker-github-action@v1
 
@@ -25,6 +20,11 @@ jobs:
       - name: Run website-stalker
         id: website-stalker
         run: website-stalker run --all --commit
+        env:
+          WEBSITE_STALKER_FROM: ${{ secrets.WEBSITE_STALKER_FROM }}
+          NOTIFICATION_TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          NOTIFICATION_TELEGRAM_TARGET_CHAT: "-1001569012086"
+          NOTIFICATION_TELEGRAM_DISABLE_WEB_PAGE_PREVIEW: true
 
       - if: success() || steps.website-stalker.outcome == 'failure'
         run: git push

--- a/website-stalker.yaml
+++ b/website-stalker.yaml
@@ -1,19 +1,9 @@
 # This is an example config
-# The filename should be `website-stalker.yaml`
-# and it should be in the working directory where you run website-stalker.
+# The filename has to be `website-stalker.yaml`
+# and it has to be in the working directory where you run website-stalker.
 #
-# For example run `website-stalker example-config > website-stalker.yaml`.
-# And then do a run via `website-stalker run`.
+# Adapt the config to your needs, then do a run via `website-stalker run`.
 ---
-notification_template: |
-  {{#sites}}
-  - {{.}}
-  {{/sites}}
-
-  {{#commit}}
-  https://github.com/EdJoPaTo/website-stalker-example/commit/{{.}}
-  {{/commit}}
-
 sites:
   # Basic example
   - url: https://edjopato.de/
@@ -67,12 +57,14 @@ sites:
       - html_markdownify
 
   - url: https://www.raspberrypi.com/software/operating-systems/
+    http1_only: true
     ignore_error: true
     editors:
       - css_select: main
       - css_remove: img
       - html_markdownify
   - url: https://assets.raspberrypi.com/page-data/software/operating-systems/page-data.json
+    http1_only: true
     ignore_error: true
     editors:
       - json_prettify


### PR DESCRIPTION
Website stalker v0.23 is not yet released, but this is how to migrate towards it.

Public example on how to do it.